### PR TITLE
feat: Make c executables static and stripped

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,8 @@ else
   CFLAGS      ?= -Os -DNDEBUG
 endif
 
+LDFLAGS        = --static --strip-all
+
 D              = $(BUILD_DIR)
 MAKEFILE_PATH  = $(lastword $(MAKEFILE_LIST))
 VPATH          = src:man


### PR DESCRIPTION
In the event that an upgrade causes an incompatible change to musl or
other libraries, the update can complete if procs-need-restart is static.
Just strip for tidiness.