### PR TITLE
rc-service-pid: Use default OpenRC libexec directory

### DIFF
--- a/src/rc-service-pid.in
+++ b/src/rc-service-pid.in
@@ -15,7 +15,7 @@ if ( set -o pipefail 2>/dev/null ); then
 	set -o pipefail
 fi
 
-readonly OPENRC_LIB='/lib/rc'
+readonly OPENRC_LIBEXEC='/usr/libexec/rc'
 
 help() {
 	sed -En '/^#---help---/,/^#---help---/p' "$0" | sed -E 's/^# ?//; 1d;$d;'
@@ -31,7 +31,7 @@ started_services() {
 
 # Prints value $2 of the service with name $1.
 service_get_value() {
-	RC_SVCNAME="$1" "$OPENRC_LIB"/bin/service_get_value "$2"
+	RC_SVCNAME="$1" "$OPENRC_LIBEXEC"/bin/service_get_value "$2"
 }
 
 # Prints PID of the service with name $1.


### PR DESCRIPTION
OpenRC defaults to /usr/libexec/rc as libexec dir. Alpine Linux uses the default value in the next 3.21 release. Another option is to make this variable configurable with a Makeflag, as this variable may not be the same on all systems.

Ref: https://gitlab.alpinelinux.org/alpine/aports/-/commit/950e9e71ba7837c5f1d6ef83b3eae460f71b5e79