### PR TITLE
Force update repository indexes

### DIFF
--- a/src/functions.sh
+++ b/src/functions.sh
@@ -112,7 +112,7 @@ procs_using_modified_files() {
 	local opts=$(printf -- '-f %s ' ${1:-*})
 
 	edebug "Executing: procs-need-restart $opts"
-	procs-need-restart -c $opts || retval=$?
+	procs-need-restart $opts || retval=$?
 
 	set +f  # enable globbing
 	return $retval

--- a/src/rc-service-pid.in
+++ b/src/rc-service-pid.in
@@ -15,7 +15,7 @@ if ( set -o pipefail 2>/dev/null ); then
 	set -o pipefail
 fi
 
-readonly OPENRC_LIB='/lib/rc'
+readonly OPENRC_LIBEXEC='/usr/libexec/rc'
 
 help() {
 	sed -En '/^#---help---/,/^#---help---/p' "$0" | sed -E 's/^# ?//; 1d;$d;'
@@ -31,7 +31,7 @@ started_services() {
 
 # Prints value $2 of the service with name $1.
 service_get_value() {
-	RC_SVCNAME="$1" "$OPENRC_LIB"/bin/service_get_value "$2"
+	RC_SVCNAME="$1" "$OPENRC_LIBEXEC"/bin/service_get_value "$2"
 }
 
 # Prints PID of the service with name $1.


### PR DESCRIPTION
Use `apk update -U` to enforce update of repository indexes, otherwise this instruction is redundant (and a bit misleading) as `apk upgrade` updates indexes if the cache have expired.

`apk update` by itself won't refresh if cache isn't expired